### PR TITLE
Update versioneer.py to work with python 3.9

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -409,9 +409,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
the configparser module in Python 3 no longer has the SafeConfigParser class, which has been replaced by configparser.ConfigParser.
The readfp method was deprecated in Python 3.2 and removed in Python 3.9. The correct method to use now is read_file.